### PR TITLE
Update home page bio and switch scheduling links to Topmate

### DIFF
--- a/src/components/cta/end-cta.astro
+++ b/src/components/cta/end-cta.astro
@@ -22,7 +22,7 @@ const { title, cta_label, bg_colour } = Astro.props;
 				class={clsx(
 					'bg-gray-900 text-white font-medium py-2 px-4 rounded-full w-fit'
 				)}
-				onclick="window.open('https://cal.com/msomu/15min', '_blank')">
+				onclick="window.open('https://topmate.io/msomu/2148374?utm_source=public_profile&utm_campaign=msomu', '_blank')">
 				{cta_label}
 			</button>
 

--- a/src/components/cta/end-cta.astro
+++ b/src/components/cta/end-cta.astro
@@ -22,7 +22,7 @@ const { title, cta_label, bg_colour } = Astro.props;
 				class={clsx(
 					'bg-gray-900 text-white font-medium py-2 px-4 rounded-full w-fit'
 				)}
-				onclick="window.open('https://topmate.io/msomu/2148374?utm_source=public_profile&utm_campaign=msomu', '_blank')">
+				onclick="window.open('https://calendar.app.google/JCPcdpQJsz6WDMid9', '_blank')">
 				{cta_label}
 			</button>
 

--- a/src/components/misc/footer.astro
+++ b/src/components/misc/footer.astro
@@ -13,7 +13,7 @@
 				resources
 			</a>
 			<a
-				href='https://topmate.io/msomu'
+				href='https://topmate.io/msomu/2148374?utm_source=public_profile&utm_campaign=msomu'
 				target='_blank'
 				rel='noopener noreferrer'
 				class='text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors capitalize'>

--- a/src/content/whoami/intro.md
+++ b/src/content/whoami/intro.md
@@ -6,4 +6,4 @@ pubDate: 'Nov 29 2024'
 
 i'm a founding ai engineer at [agi inc](https://x.com/agi_inc), building at the frontier of ai. outside of work, i founded [united by ai](https://x.com/unitedbyai) to bring ai builders together, and i organise [gdg chennai](https://x.com/gdgchennai). before all this, i was at disney+hotstar, crafting streaming experiences for millions.
 
-want to chat? [schedule a call](https://calendar.app.google/JCPcdpQJsz6WDMid9)
+want to chat? [book a call on topmate](https://topmate.io/msomu/2148374?utm_source=public_profile&utm_campaign=msomu)

--- a/src/content/whoami/intro.md
+++ b/src/content/whoami/intro.md
@@ -1,9 +1,9 @@
 ---
 title: "meet somu, android craftsman"
-description: "Senior Android Developer at JioHotstar. Specializing in streaming and entertainment apps. Community leader at GDG Chennai. Always building."
+description: "Founding AI Engineer at AGI Inc. Founder at United by AI. Organiser at GDG Chennai. Ex-Disney+Hotstar. Always building."
 pubDate: 'Nov 29 2024'
 ---
 
-i build android apps at [jiohotstar](https://www.hotstar.com), crafting streaming experiences for millions. 10+ years shipping mobile solutions. i solve hard problems at scale.
+founding ai engineer at [agi inc](https://x.com/agi_inc). founder at [united by ai](https://x.com/unitedbyai). organiser at [gdg chennai](https://x.com/gdgchennai). ex-disney+hotstar.
 
 want to chat? [schedule a call](https://calendar.app.google/JCPcdpQJsz6WDMid9)

--- a/src/content/whoami/intro.md
+++ b/src/content/whoami/intro.md
@@ -1,9 +1,9 @@
 ---
 title: "meet somu, android craftsman"
-description: "Founding AI Engineer at AGI Inc. Founder at United by AI. Organiser at GDG Chennai. Ex-Disney+Hotstar. Always building."
+description: "Founding AI Engineer at AGI Inc. Founder of United by AI. Organiser at GDG Chennai. Previously crafted streaming experiences for millions at Disney+Hotstar."
 pubDate: 'Nov 29 2024'
 ---
 
-founding ai engineer at [agi inc](https://x.com/agi_inc). founder at [united by ai](https://x.com/unitedbyai). organiser at [gdg chennai](https://x.com/gdgchennai). ex-disney+hotstar.
+i'm a founding ai engineer at [agi inc](https://x.com/agi_inc), building at the frontier of ai. outside of work, i founded [united by ai](https://x.com/unitedbyai) to bring ai builders together, and i organise [gdg chennai](https://x.com/gdgchennai). before all this, i spent a decade at disney+hotstar, crafting streaming experiences for millions.
 
 want to chat? [schedule a call](https://calendar.app.google/JCPcdpQJsz6WDMid9)

--- a/src/content/whoami/intro.md
+++ b/src/content/whoami/intro.md
@@ -4,6 +4,6 @@ description: "Founding AI Engineer at AGI Inc. Founder of United by AI. Organise
 pubDate: 'Nov 29 2024'
 ---
 
-i'm a founding ai engineer at [agi inc](https://x.com/agi_inc), building at the frontier of ai. outside of work, i founded [united by ai](https://x.com/unitedbyai) to bring ai builders together, and i organise [gdg chennai](https://x.com/gdgchennai). before all this, i spent a decade at disney+hotstar, crafting streaming experiences for millions.
+i'm a founding ai engineer at [agi inc](https://x.com/agi_inc), building at the frontier of ai. outside of work, i founded [united by ai](https://x.com/unitedbyai) to bring ai builders together, and i organise [gdg chennai](https://x.com/gdgchennai). before all this, i was at disney+hotstar, crafting streaming experiences for millions.
 
 want to chat? [schedule a call](https://calendar.app.google/JCPcdpQJsz6WDMid9)


### PR DESCRIPTION
## Summary
- Rewrite the home page bio in `src/content/whoami/intro.md` in a warm first-person voice reflecting current roles: founding ai engineer at agi inc, founder of united by ai, organiser at gdg chennai, previously at disney+hotstar (each linked to its X profile)
- Update the frontmatter `description` (used as screen-reader text on the homepage) to match
- Update the call-scheduling links:
  - `src/content/whoami/intro.md` — "schedule a call" → "book a call on topmate" pointing to the Topmate booking link (`https://topmate.io/msomu/2148374?utm_source=public_profile&utm_campaign=msomu`)
  - `src/components/misc/footer.astro` — bare topmate profile link → full Topmate booking link
  - `src/components/cta/end-cta.astro` — end-of-post CTA button now opens the Google Calendar quick-call link (`https://calendar.app.google/JCPcdpQJsz6WDMid9`) instead of cal.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014osHqUojjXa7TzX3r7gAv5